### PR TITLE
feat: add four props that can change the width/height of the elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,15 @@ $ yarn add vue-feedback-reaction
 
 ## Props
 
-| Property name | Type                  | Default | Description                                                                        |
-|---------------|-----------------------|---------|------------------------------------------------------------------------------------|
-| value         | String, Number        | ''      | Input value (v-model)                                                              |
-| labels        | Array                 | []      | Array of strings that set labels below each emoji reaction, starting from the left |
-| labelClass    | Object, Array, String | ''      | Only works if you are using the labels prop. Set a v-bind:class to all the labels  |
+| Property name   | Type                  | Default | Description                                                                        |
+|-----------------|-----------------------|---------|------------------------------------------------------------------------------------|
+| value           | String, Number        | ''      | Input value (v-model)                                                              |
+| labels          | Array                 | []      | Array of strings that set labels below each emoji reaction, starting from the left |
+| labelClass      | Object, Array, String | ''      | Only works if you are using the labels prop. Set a v-bind:class to all the labels  |
+| emojiWidth      | String, Number        | ''      | Set a width for all emojis                                                         |
+| emojiHeight     | String, Number        | ''      | Set a height for all emojis                                                        |
+| containerWidth  | String, Number        | ''      | Set the containers width                                                           |
+| containerHeight | String, Number        | ''      | Set the containers height                                                          |
 
 ## License
 

--- a/src/components/VueFeedbackReaction.vue
+++ b/src/components/VueFeedbackReaction.vue
@@ -1,19 +1,19 @@
 <template lang="pug">
-  .vue-feedback-reaction
+  .vue-feedback-reaction(:style="{ width: containerWidth, height: containerHeight }")
     .reaction
-      vue-reaction(v-model="reactionValue" reaction="1" :hover-image="hate" :image="hateInactive" :selected-image="hateActive")
+      vue-reaction(v-model="reactionValue" reaction="1" :hover-image="hate" :image="hateInactive" :selected-image="hateActive" :width="emojiWidth" :height="emojiHeight")
       span(:class="labelClass") {{ labels[0] || '' }}
     .reaction
-      vue-reaction(v-model="reactionValue" reaction="2" :hover-image="disappointed" :image="disappointedInactive" :selected-image="disappointedActive")
+      vue-reaction(v-model="reactionValue" reaction="2" :hover-image="disappointed" :image="disappointedInactive" :selected-image="disappointedActive" :width="emojiWidth" :height="emojiHeight")
       span(:class="labelClass") {{ labels[1] || '' }}
     .reaction
-      vue-reaction(v-model="reactionValue" reaction="3" :hover-image="natural" :image="naturalInactive" :selected-image="naturalActive")
+      vue-reaction(v-model="reactionValue" reaction="3" :hover-image="natural" :image="naturalInactive" :selected-image="naturalActive" :width="emojiWidth" :height="emojiHeight")
       span(:class="labelClass") {{ labels[2] || '' }}
     .reaction
-      vue-reaction(v-model="reactionValue" reaction="4" :hover-image="good" :image="goodInactive" :selected-image="goodActive")
+      vue-reaction(v-model="reactionValue" reaction="4" :hover-image="good" :image="goodInactive" :selected-image="goodActive" :width="emojiWidth" :height="emojiHeight")
       span(:class="labelClass") {{ labels[3] || '' }}
     .reaction
-      vue-reaction(v-model="reactionValue" reaction="5" :hover-image="excellent" :image="excellentInactive" :selected-image="excellentActive")
+      vue-reaction(v-model="reactionValue" reaction="5" :hover-image="excellent" :image="excellentInactive" :selected-image="excellentActive" :width="emojiWidth" :height="emojiHeight")
       span(:class="labelClass") {{ labels[4] || '' }}
 </template>
 
@@ -53,6 +53,22 @@ export default {
     labelClass: {
       default: '',
       type: [Object, Array, String]
+    },
+    emojiWidth: {
+      default: '',
+      type: [String, Number]
+    },
+    emojiHeight: {
+      default: '',
+      type: [String, Number]
+    },
+    containerWidth: {
+      default: '',
+      type: [String, Number]
+    },
+    containerHeight: {
+      default: '',
+      type: [String, Number]
     }
   },
   mounted () {
@@ -93,9 +109,13 @@ export default {
   display inline-flex
   .reaction
     position relative
-    display inline-block
+    display flex
+    flex-direction column
+    justify-content center
+    align-items center
     -webkit-transition all .2s ease
     transition all .2s ease
-    margin-right 8px
+    margin 0 auto
+    padding 0 8px
     cursor pointer
 </style>

--- a/src/components/VueReaction.vue
+++ b/src/components/VueReaction.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
-  .vue-reaction
-    img(:src="currentImage" v-on="listeners" @click="updateActiveReaction" @keydown.space="updateActiveReaction")
+  .vue-reaction(:style="{ width, height }")
+    img(:src="currentImage" v-on="listeners" @click="updateActiveReaction" @keydown.space="updateActiveReaction" :style="{ width, height }")
     .effect
 </template>
 
@@ -23,6 +23,12 @@ export default {
     },
     reaction: {
       type: String
+    },
+    width: {
+      type: [String, Number]
+    },
+    height: {
+      type: [String, Number]
     }
   },
   data () {
@@ -67,6 +73,8 @@ export default {
   display flex
   -webkit-transition all .2s ease
   transition all .2s ease
+  justify-content center
+  align-items center
   cursor pointer
   height 60px
   width 58px


### PR DESCRIPTION
ref #4.
This PR adds four new props that allows you to set a fixed height/width of the emojis aswell the whole container.
Bellow has a few examples and a comparison with right now.

**Right now in github.io:**

![image](https://user-images.githubusercontent.com/22016005/69815893-1323ac80-11d6-11ea-9e04-29422a0778bb.png)

**Default with this PR:**

![image](https://user-images.githubusercontent.com/22016005/69815922-20d93200-11d6-11ea-9438-fbc775245438.png)

**Using the props:**

1. containerWidth: 800px;
2. containerHeight: 500px;
3. emojiWidth: 100px;
4. emojiHeight: 100px;

![image](https://user-images.githubusercontent.com/22016005/69816038-5bdb6580-11d6-11ea-93bf-539c7cb47577.png)

I had to change the CSS a little bit.
The `README.md` was also updated with this new props.
Any changes let me know.

------------------------------------------------

**Question:**

Do you have any plans or a date to generate a new release in npm? This PR (if acceptable) and the labels one would help me a lot :smile:

Thank you.

